### PR TITLE
WIP: Adds new distinct option to :options

### DIFF
--- a/test/database.sql
+++ b/test/database.sql
@@ -212,6 +212,25 @@ CREATE TABLE table_with_composite_key (
   name TEXT
 );
 
+CREATE TABLE parent_table (
+  id SERIAL PRIMARY KEY
+);
+
+CREATE TABLE with_possible_duplicates (
+  parent_id INTEGER REFERENCES parent_table (id),
+  "tag" text
+);
+
+INSERT INTO parent_table VALUES (1), (2), (3);
+
+INSERT INTO with_possible_duplicates VALUES
+(1, 'foo'),
+(1, 'bar'),
+(2, 'foo'),
+(3, 'bar')
+;
+
+
 -- Some tables for multiple has-many join tests
 
 -- CREATE TABLE customer (

--- a/test/specql/core_test.clj
+++ b/test/specql/core_test.clj
@@ -66,6 +66,9 @@
 
   ["recipient" :recipient/recipient]
   ["mailinglist" :mailinglist/mailinglist]
+
+  ["parent_table" :parent-table/parent-table]
+  ["with_possible_duplicates" :with-possible-duplicates/with-possible-duplicates]
   )
 
 (defmacro asserted [msg-regex & body]
@@ -103,6 +106,68 @@
                                   :employee/employees
                                   #{:employee/foo}
                                   {}))))
+(:with-possible-duplicates/with-possible-duplicates @specql.impl.registry/table-info-registry)
+(deftest distinct-option
+  (testing "Table contains expected data"
+    (is (= (list #:with-possible-duplicates{:parent_id 1 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 1 :tag "bar"}
+                 #:with-possible-duplicates{:parent_id 2 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 3 :tag "bar"})
+
+           (fetch db
+                  ;; table
+                  :with-possible-duplicates/with-possible-duplicates
+                  ;; columns
+                  #{:with-possible-duplicates/parent_id
+                    :with-possible-duplicates/tag}
+                  ;; where
+                  {}
+                  {::specql/order-by :with-possible-duplicates/parent_id}))))
+
+  (testing "Distinct false uses `SELECT ALL`"
+    (is (= (list #:with-possible-duplicates{:parent_id 1 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 1 :tag "bar"}
+                 #:with-possible-duplicates{:parent_id 2 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 3 :tag "bar"})
+
+           (fetch db
+                  ;; table
+                  :with-possible-duplicates/with-possible-duplicates
+                  ;; columns
+                  #{:with-possible-duplicates/parent_id
+                    :with-possible-duplicates/tag}
+                  ;; where
+                  {}
+                  {::specql/distinct false}))))
+
+
+  (testing "Distinct true removes duplicates"
+    (is (= (list #:with-possible-duplicates{:tag "foo"}
+                 #:with-possible-duplicates{:tag "bar"})
+
+           (fetch db
+                  ;; table
+                  :with-possible-duplicates/with-possible-duplicates
+                  ;; columns
+                  #{:with-possible-duplicates/tag}
+                  ;; where
+                  {}
+                  {::specql/distinct true}))))
+
+  (testing "Distinct with seq of columns removes duplicates across columns"
+    (is (= (list #:with-possible-duplicates{:parent_id 1 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 2 :tag "foo"}
+                 #:with-possible-duplicates{:parent_id 3 :tag "bar"})
+
+           (fetch db
+                  ;; table
+                  :with-possible-duplicates/with-possible-duplicates
+                  ;; columns
+                  #{:with-possible-duplicates/parent_id
+                    :with-possible-duplicates/tag}
+                  ;; where
+                  {}
+                  {::specql/distinct #{:with-possible-duplicates/parent_id}})))))
 
 (deftest query-with-invalid-parameter
   (let [x "foo"]


### PR DESCRIPTION
Adds option for doing SELECT DISTINCT and SELECT DISTINCT ON in fetch, see #45 for more details.

Here's the initial implementation idea. I'm a little bit hesitant because of the stuff in all-cols, which is like this in the test.

```
{:par2
 ["wit1.\"parent_id\""
  [:with-possible-duplicates/parent_id] ;; <- column key is inside a vector, why?
  {:category "N",
   :not-null? false,
   :has-default? false,
   :primary-key? false,
   :number 1,
   :name "parent_id",
   :type "int4",
   :enum? false,
   :type-specific-data -1}],
 :tag3
 ["wit1.\"tag\""
  [:with-possible-duplicates/tag]
  {:category "S",
   :not-null? false,
   :has-default? false,
   :primary-key? false,
   :number 2,
   :name "tag",
   :type "text",
   :enum? false,
   :type-specific-data -1}]}
```

Can I assume the column name will always be first element in that vector? Or should I translate the column list to look like :par2, :par3 instead of the column keys?