### PR TITLE
Memoize composite types, to make inserting faster

### DIFF
--- a/src/specql/impl/registry.cljc
+++ b/src/specql/impl/registry.cljc
@@ -31,15 +31,19 @@
    (get table-info-registry
         (type-keyword-by-name table-info-registry type-name))))
 
+(def composite-type*
+  (memoize (fn [table-info-registry name]
+             (some (fn [[key {n :name t :type}]]
+                     (and (= :composite t)
+                          (= name n)
+                          key))
+                   table-info-registry))))
+
 (defn composite-type
   "Find user defined composite type from registry by name."
   ([name] (composite-type @table-info-registry name))
   ([table-info-registry name]
-   (some (fn [[key {n :name t :type}]]
-           (and (= :composite t)
-                (= name n)
-                key))
-         table-info-registry)))
+   (composite-type* table-info-registry name)))
 
 (defn enum-type
   "Find an enum type from registry by name."

--- a/src/specql/impl/registry.cljc
+++ b/src/specql/impl/registry.cljc
@@ -31,19 +31,15 @@
    (get table-info-registry
         (type-keyword-by-name table-info-registry type-name))))
 
-(def composite-type*
-  (memoize (fn [table-info-registry name]
-             (some (fn [[key {n :name t :type}]]
-                     (and (= :composite t)
-                          (= name n)
-                          key))
-                   table-info-registry))))
-
 (defn composite-type
   "Find user defined composite type from registry by name."
   ([name] (composite-type @table-info-registry name))
   ([table-info-registry name]
-   (composite-type* table-info-registry name)))
+   (some (fn [[key {n :name t :type}]]
+           (and (= :composite t)
+                (= name n)
+                key))
+         table-info-registry)))
 
 (defn enum-type
   "Find an enum type from registry by name."

--- a/src/specql/impl/util.clj
+++ b/src/specql/impl/util.clj
@@ -85,6 +85,8 @@
              record)))
        record record))))
 
+(def mem-composite-type (memoize registry/composite-type))
+
 (defn columns-and-values-to-set
   "Return columns and values for set (update or insert)"
   [table-info-registry table record]
@@ -108,8 +110,8 @@
                    columns)
 
             ;; A composite type
-            (registry/composite-type table-info-registry (:type column))
-            (let [composite-type-kw (registry/composite-type table-info-registry (:type column))
+            (mem-composite-type table-info-registry (:type column))
+            (let [composite-type-kw (mem-composite-type table-info-registry (:type column))
                   composite-type (table-info-registry composite-type-kw)
                   composite-columns (:columns composite-type)]
               (recur (conj names (:name column))


### PR DESCRIPTION
When many records are inserted to a table with many columns, this function is called for every column and going through the whole table registry repeatedly becomes slow.

By memoizing the function the logic is evaluated once, but will be re-evaluated in the case table registry changes