### PR TITLE
Add reader conditional for clj/cljs

### DIFF
--- a/src/specql/data_types.cljc
+++ b/src/specql/data_types.cljc
@@ -10,8 +10,9 @@
 (s/def ::varchar string?)
 
 ;; Postgres can handle upto 4713 BC, but do we need it?
-(s/def ::date (s/inst-in #inst "0001-01-01T00:00:00.000-00:00"
-                         #inst "9999-12-31T23:59:59.999-00:00"))
+(s/def ::date #?(:clj (s/inst-in #inst "0001-01-01T00:00:00.000-00:00"
+                                 #inst "9999-12-31T23:59:59.999-00:00")
+                 :cljs any?))
 (s/def ::timestamp ::date)
 (s/def ::timestamptz ::date)
 (s/def ::time #?(:clj #(instance? java.time.LocalTime %)


### PR DESCRIPTION
Removes compile error when trying to use file in clojurescript.

When we upgraded clojurescript in our project, we got compile errors from referencing java.time.Instant from cljs side. Adding reader conditionals removes the compile error but admittedly does not provide a really sensible spec for the cljs side.